### PR TITLE
Fix ascii encoding error & remove punctuation from search terms

### DIFF
--- a/Notebooks/GeniusAPI.ipynb
+++ b/Notebooks/GeniusAPI.ipynb
@@ -23,13 +23,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 64,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
     "import re\n",
+    "from string import punctuation\n",
     "import requests\n",
     "import json\n",
     "from bs4 import BeautifulSoup\n",
@@ -40,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 65,
    "metadata": {
     "collapsed": true
    },
@@ -61,17 +62,17 @@
     "        try: self._body = json_dict['song']\n",
     "        except: self._body = json_dict\n",
     "        self._body['lyrics'] = lyrics\n",
-    "        self._url      = str(self._body['url'])\n",
-    "        self._api_path = str(self._body['api_path'])\n",
-    "        self._id       = str(self._body['id'])  \n",
+    "        self._url      = self._body['url']\n",
+    "        self._api_path = self._body['api_path']\n",
+    "        self._id       = self._body['id']\n",
     "                                                        \n",
     "    @property\n",
     "    def title(self):\n",
-    "        return str(self._body['title'])\n",
+    "        return str(self._body['title'].encode('ascii',errors='ignore'))\n",
     "\n",
     "    @property\n",
     "    def artist(self):\n",
-    "        return str(self._body['primary_artist']['name'])\n",
+    "        return str(self._body['primary_artist']['name'].encode('ascii',errors='ignore'))\n",
     "\n",
     "    @property\n",
     "    def lyrics(self):\n",
@@ -79,24 +80,24 @@
     "        \n",
     "    @property\n",
     "    def album(self):\n",
-    "        try: return str(self._body['album']['name'])\n",
+    "        try: return self._body['album']['name']\n",
     "        except: return ''\n",
     "            \n",
     "    @property\n",
     "    def year(self):\n",
-    "        return str(self._body['release_date'])\n",
+    "        return self._body['release_date']\n",
     "    \n",
     "    @property\n",
     "    def url(self):\n",
-    "        return str(self._body['url'])\n",
+    "        return self._body['url']\n",
     "    \n",
     "    @property\n",
     "    def album_url(self):\n",
-    "        return str(self._body['album']['url'])\n",
+    "        return self._body['album']['url']\n",
     "    \n",
     "    @property\n",
     "    def featured_artists(self):\n",
-    "        return str(self._body['featured_artists'])\n",
+    "        return self._body['featured_artists']\n",
     "    \n",
     "    @property\n",
     "    def media(self):\n",
@@ -107,14 +108,13 @@
     "    @property\n",
     "    def writer_artists(self):\n",
     "        \"\"\"List of artists credited as writers\"\"\"\n",
-    "        writers = []\n",
-    "        [writers.append((str(writer['name']),str(writer['id']),str(writer['url'])))\\\n",
-    "                        for writer in self._body['writer_artists']]\n",
+    "        writers = []                \n",
+    "        [writers.append((writer['name'], writer['id'], writer['url'])) for writer in self._body['writer_artists']]\n",
     "        return writers\n",
     "    \n",
     "    @property\n",
     "    def song_art_image_url(self):\n",
-    "        return str(self._body['song_art_image_url'])\n",
+    "        return self._body['song_art_image_url']\n",
     "\n",
     "    def __str__(self):\n",
     "        \"\"\"Return a string representation of the Song object.\"\"\"\n",
@@ -146,19 +146,19 @@
     "    def __init__(self, json_dict):\n",
     "        \"\"\"Populate the Artist object with the data from *json_dict*\"\"\"\n",
     "        self._body = json_dict['artist']\n",
-    "        self._url      = str(self._body['url'])\n",
-    "        self._api_path = str(self._body['api_path'])\n",
-    "        self._id       = str(self._body['id']) \n",
+    "        self._url      = self._body['url']\n",
+    "        self._api_path = self._body['api_path']\n",
+    "        self._id       = self._body['id']\n",
     "        self._songs = []\n",
     "        self._num_songs = len(self._songs)\n",
     "        \n",
     "    @property\n",
-    "    def name(self):\n",
-    "        return str(self._body['name'])\n",
+    "    def name(self):            \n",
+    "        return str(self._body['name'].encode('ascii',errors='ignore'))\n",
     "                    \n",
     "    @property\n",
     "    def image_url(self):\n",
-    "        return str(self._body['image_url'])        \n",
+    "        return self._body['image_url']\n",
     "    \n",
     "    @property\n",
     "    def songs(self):\n",
@@ -217,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 66,
    "metadata": {
     "collapsed": true
    },
@@ -252,7 +252,7 @@
     "        \n",
     "    def _load_credentials(self):\n",
     "        \"\"\"Load the Genius.com API authorization information from the 'credentials.ini' file\"\"\"        \n",
-    "        lines = [str(line.rstrip('\\n')) for line in open('../credentials.ini')]        \n",
+    "        lines = [str(line.rstrip('\\n')) for line in open('../genius/credentials.ini')]        \n",
     "        for line in lines:\n",
     "            if \"client_id\" in line:\n",
     "                client_id = line.split(\": \")[1]\n",
@@ -292,7 +292,7 @@
     "                print(\"Timeout raised and caught\")\n",
     "                continue\n",
     "            break\n",
-    "\n",
+    "                                \n",
     "        return json.loads(raw)['response']\n",
     "        \n",
     "    def _format_api_request(self, term_and_type, page=1):\n",
@@ -323,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 107,
    "metadata": {
     "collapsed": true
    },
@@ -346,11 +346,14 @@
     "        # Loop through search results, stopping as soon as title and artist of result match request\n",
     "        n_hits = min(10,len(json_search['hits']))\n",
     "        for i in range(n_hits):\n",
-    "            search_hit   = json_search['hits'][i]['result']\n",
-    "            found_title  = str(search_hit['title']).translate(None,' ').lower()\n",
-    "            found_artist = str(search_hit['primary_artist']['name']).translate(None,' ').lower()\n",
-    "\n",
-    "            if found_title == song_title.translate(None,' ').lower() and (found_artist == artist_name.translate(None,' ').lower() or artist_name==''):\n",
+    "            search_hit   = json_search['hits'][i]['result']                                                            \n",
+    "            \n",
+    "            found_title  = str(search_hit['title'].encode('ascii', errors='ignore')).lower().translate(None, punctuation)\n",
+    "            found_artist = str(search_hit['primary_artist']['name'].encode('ascii', errors='ignore')).lower().translate(None, punctuation)\n",
+    "                                    \n",
+    "            # Download song from Genius.com if title and artist match the request\n",
+    "            if found_title == song_title.lower().translate(None, punctuation) and \\\n",
+    "              (found_artist == artist_name.translate(None, punctuation).lower() or artist_name==''):\n",
     "                # Found correct song, accessing API ID\n",
     "                json_song = self._make_api_request((search_hit['id'],'song'))\n",
     "                \n",
@@ -359,6 +362,7 @@
     "\n",
     "                # Create the Song object\n",
     "                song = Song(json_song, lyrics)\n",
+    "                                \n",
     "                print('Done.\\n')        \n",
     "                return song\n",
     "        \n",
@@ -373,9 +377,10 @@
     "    \n",
     "        # Perform a Genius API search for the artist                \n",
     "        json_search = self._make_api_request((artist_name,'search'))                        \n",
-    "        for hit in json_search['hits']:                                          \n",
-    "            if str(hit['result']['primary_artist']['name']).lower()==artist_name.lower():                \n",
-    "                artist_id = str(hit['result']['primary_artist']['id'])                                                                \n",
+    "        for hit in json_search['hits']:\n",
+    "            found_artist = hit['result']['primary_artist']\n",
+    "            if str(found_artist['name'].encode('ascii',errors='ignore')).lower()==artist_name.lower():                \n",
+    "                artist_id = found_artist['id']\n",
     "                break\n",
     "            else:                                                            \n",
     "                artist_id = None                                                                                        \n",
@@ -437,61 +442,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "G = Genius()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Searching for \"Begin Again\"...\n"
-     ]
-    },
-    {
-     "ename": "UnicodeEncodeError",
-     "evalue": "'ascii' codec can't encode character u'\\u200b' in position 0: ordinal not in range(128)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mUnicodeEncodeError\u001b[0m                        Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-12-4ea6a8ec21f2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msong\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mG\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msearch_song\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Begin Again'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0msong\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-9-d7f71b2342e5>\u001b[0m in \u001b[0;36msearch_song\u001b[0;34m(self, song_title, artist_name)\u001b[0m\n\u001b[1;32m     17\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_hits\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m             \u001b[0msearch_hit\u001b[0m   \u001b[0;34m=\u001b[0m \u001b[0mjson_search\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'hits'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'result'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m             \u001b[0mfound_title\u001b[0m  \u001b[0;34m=\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msearch_hit\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'title'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtranslate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' '\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlower\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     20\u001b[0m             \u001b[0mfound_artist\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msearch_hit\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'primary_artist'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'name'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtranslate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' '\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlower\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mUnicodeEncodeError\u001b[0m: 'ascii' codec can't encode character u'\\u200b' in position 0: ordinal not in range(128)"
-     ]
-    }
-   ],
-   "source": [
-    "song = G.search_song('Begin Again')\n",
-    "song\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Searching for \"Electric Relaxation\" by A Tribe Called Quest...\n",
+      "Done.\n",
       "\n",
-      "Searching for \"Electric Relaxation\" by A Tribe Called Quest...  Done.\n",
-      "Electric Relaxation by A Tribe Called Quest:\n",
-      "\"Relax yourself girl, please set-tle down\n",
-      "Relax yourself girl, please set-tle down\n",
-      "Relax yourself gir...\"\n"
+      "\"Electric Relaxation\" by A Tribe Called Quest:\n",
+      "    Relax yourself girl, please set-tle down\n",
+      "    Relax yourself girl, please set-tle down\n",
+      "    Relax yourself gir...\n"
      ]
     }
    ],

--- a/Notebooks/GeniusAPI.ipynb
+++ b/Notebooks/GeniusAPI.ipynb
@@ -10,11 +10,12 @@
     "### Usage ###\n",
     "```python\n",
     "# Here's how I envision the final form of the GeniusAPI.py file and the song and artist classes\n",
-    "import GeniusAPI as Genius\n",
+    "from genius import Genius\n",
+    "G = Genius()\n",
     "\n",
-    "song1 = Genius.search_song('Yesterday','The Beatles') # Song object\n",
-    "song2 = Genius.search_song('Prom Night','Chance the Rapper')\n",
-    "artist = Genius.search_artist('Michael Jackson') # Artist object\n",
+    "song1 = G.search_song('Yesterday','The Beatles') # Song object\n",
+    "song2 = G.search_song('Prom Night','Chance the Rapper')\n",
+    "artist = G.search_artist('Michael Jackson') # Artist object\n",
     "```\n",
     "\n",
     "***Scroll to bottom of notebook for full demonstration of code***"
@@ -22,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -39,12 +40,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "class Song():        \n",
-    "    # Would it make more sense for these data classes to all inherit from __dict__ ?\n",
+    "class Song():    \n",
     "    \"\"\"A song from the Genius.com database.\n",
     "    \n",
     "    Attributes:\n",
@@ -119,7 +121,7 @@
     "        if len(self.lyrics) > 100:\n",
     "            lyr = self.lyrics[:100] + \"...\"\n",
     "        else: lyr = self.lyrics[:100]            \n",
-    "        return '{title} by {artist}:\\n\"{lyrics}\"'.format(title=self.title,artist=self.artist,lyrics=lyr)         \n",
+    "        return '\"{title}\" by {artist}:\\n    {lyrics}'.format(title=self.title,artist=self.artist,lyrics=lyr.replace('\\n','\\n    '))       \n",
     "    \n",
     "    def __repr__(self):\n",
     "        return repr((self.title, self.artist))\n",
@@ -130,6 +132,7 @@
     "    def __list__(self):\n",
     "        # How do I do this?\n",
     "        return\n",
+    "               \n",
     "                \n",
     "class Artist():\n",
     "    \"\"\"An artist from the Genius.com database.\n",
@@ -192,7 +195,8 @@
     "            return '{0}, {1} songs'.format(self.name,self._num_songs)\n",
     "    \n",
     "    def __repr__(self):\n",
-    "        return repr((self.name, '{0} songs'.format(self._num_songs)))                                    "
+    "        return repr((self.name, '{0} songs'.format(self._num_songs)))  \n",
+    "                                 "
    ]
   },
   {
@@ -213,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -247,18 +251,16 @@
     "        self._HEADER_AUTHORIZATION = 'Bearer ' + self._CLIENT_ACCESS_TOKEN        \n",
     "        \n",
     "    def _load_credentials(self):\n",
-    "        \"\"\"Load the Genius.com API authorization information from the 'credentials.ini' file\"\"\"\n",
-    "        # https://github.com/jasonqng/genius-lyrics-search                \n",
-    "        lines = [line.rstrip('\\n') for line in open('credentials.ini')]\n",
-    "        chars_to_strip = \" \\'\\\"\"\n",
+    "        \"\"\"Load the Genius.com API authorization information from the 'credentials.ini' file\"\"\"        \n",
+    "        lines = [str(line.rstrip('\\n')) for line in open('../credentials.ini')]        \n",
     "        for line in lines:\n",
     "            if \"client_id\" in line:\n",
-    "                client_id = re.findall(r'[\\\"\\']([^\\\"\\']*)[\\\"\\']', line)[0]\n",
+    "                client_id = line.split(\": \")[1]\n",
     "            if \"client_secret\" in line:\n",
-    "                client_secret = re.findall(r'[\\\"\\']([^\\\"\\']*)[\\\"\\']', line)[0]\n",
+    "                client_secret = line.split(\": \")[1]\n",
     "            #Currently only need access token to run, the other two perhaps for future implementation\n",
     "            if \"client_access_token\" in line:\n",
-    "                client_access_token = re.findall(r'[\\\"\\']([^\\\"\\']*)[\\\"\\']', line)[0]\n",
+    "                client_access_token = line.split(\": \")[1]\n",
     "                \n",
     "        return client_access_token\n",
     "    \n",
@@ -321,8 +323,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "class Genius(_GeniusAPI):\n",
@@ -330,10 +334,12 @@
     "    \n",
     "    def search_song(self, song_title, artist_name=''):\n",
     "        \"\"\"Search Genius.com for *song_title* by *artist_name*\"\"\"                \n",
-    "    \n",
+    "                    \n",
     "        # Perform a Genius API search for the song\n",
-    "        if artist_name != '': print('\\nSearching for \"{0}\" by {1}...'.format(song_title,artist_name)),\n",
-    "        else: print('\\nSearching for \"{0}\"...'.format(song_title)),\n",
+    "        if artist_name != '':            \n",
+    "            print('Searching for \"{0}\" by {1}...'.format(song_title,artist_name))\n",
+    "        else:            \n",
+    "            print('Searching for \"{0}\"...'.format(song_title))\n",
     "        search_term = song_title + ' ' + artist_name\n",
     "        json_search = self._make_api_request((search_term,'search'))        \n",
     "                \n",
@@ -344,8 +350,7 @@
     "            found_title  = str(search_hit['title']).translate(None,' ').lower()\n",
     "            found_artist = str(search_hit['primary_artist']['name']).translate(None,' ').lower()\n",
     "\n",
-    "            if found_title == song_title.translate(None,' ').lower() and\\\n",
-    "                    (found_artist == artist_name.translate(None,' ').lower() or artist_name==''):\n",
+    "            if found_title == song_title.translate(None,' ').lower() and (found_artist == artist_name.translate(None,' ').lower() or artist_name==''):\n",
     "                # Found correct song, accessing API ID\n",
     "                json_song = self._make_api_request((search_hit['id'],'song'))\n",
     "                \n",
@@ -354,24 +359,27 @@
     "\n",
     "                # Create the Song object\n",
     "                song = Song(json_song, lyrics)\n",
-    "                print(' Done.')        \n",
+    "                print('Done.\\n')        \n",
     "                return song\n",
     "        \n",
-    "        print(' Specified song was not first result :(')\n",
+    "        print('Specified song was not first result :(')\n",
     "        return None\n",
     "        \n",
-    "    def search_artist(self, artist_name, get_songs=True, verbose=True):\n",
+    "    def search_artist(self, artist_name, get_songs=True, verbose=True, max_songs=None):\n",
     "        \"\"\"Allow user to search for an artist on the Genius.com database by supplying an artist name.\n",
     "        Returns an Artist() object containing all songs for that particular artist.\"\"\"\n",
     "                                \n",
-    "        print('\\nSearching for {0}...'.format(artist_name)),\n",
+    "        print('Searching for {0}...\\n'.format(artist_name))\n",
     "    \n",
-    "        # Perform a Genius API search for the artist        \n",
-    "        json_search = self._make_api_request((artist_name,'search'))        \n",
-    "        for hit in json_search['hits']:\n",
-    "            if hit['result']['primary_artist']['name']==artist_name:\n",
-    "                artist_id = str(hit['result']['primary_artist']['id'])\n",
-    "                break            \n",
+    "        # Perform a Genius API search for the artist                \n",
+    "        json_search = self._make_api_request((artist_name,'search'))                        \n",
+    "        for hit in json_search['hits']:                                          \n",
+    "            if str(hit['result']['primary_artist']['name']).lower()==artist_name.lower():                \n",
+    "                artist_id = str(hit['result']['primary_artist']['id'])                                                                \n",
+    "                break\n",
+    "            else:                                                            \n",
+    "                artist_id = None                                                                                        \n",
+    "        assert (not isinstance(artist_id,type(None))), \"Could not find artist. Check spelling?\"\n",
     "        \n",
     "        # Make Genius API request for the determined artist ID\n",
     "        json_artist = self._make_api_request((artist_id,'artist'))\n",
@@ -379,14 +387,14 @@
     "        # Create the Artist object\n",
     "        artist = Artist(json_artist);\n",
     "        \n",
-    "        if get_songs == True:\n",
-    "            print('\\nSearching for songs...')\n",
+    "        if get_songs == True:            \n",
     "            # Access the api_path found by searching\n",
     "            artist_search_results = self._make_api_request((artist_id, 'artist-songs'))        \n",
     "\n",
     "            # Download each song by artist, store as Song objects in Artist object\n",
-    "            next_page = 0; n=0\n",
-    "            while True:            \n",
+    "            keep_searching = True\n",
+    "            next_page = 0; n=0            \n",
+    "            while keep_searching:            \n",
     "                for json_song in artist_search_results['songs']:\n",
     "                    # Scrape song lyrics from the song's HTML\n",
     "                    lyrics = self._scrape_song_lyrics_from_url(json_song['url'])            \n",
@@ -398,9 +406,16 @@
     "                        if verbose==True:\n",
     "                            try: print('Song {0}: \"{1}\"'.format(n,song.title))\n",
     "                            except: pass\n",
+    "                    \n",
+    "                    # Check if user specified a max number of songs for the artist\n",
+    "                    if not isinstance(max_songs,type(None)):\n",
+    "                        if artist.num_songs >= max_songs:\n",
+    "                            keep_searching = False\n",
+    "                            print('\\nReached user-specified song limit ({0}).'.format(max_songs))\n",
+    "                            break\n",
     "\n",
     "                # Move on to next page of search results\n",
-    "                next_page = artist_search_results['next_page']\n",
+    "                next_page = artist_search_results['next_page']                \n",
     "                if next_page == None:\n",
     "                    break\n",
     "                else: # Get next page of artist song results\n",
@@ -408,7 +423,7 @@
     "\n",
     "            print('Found {n_songs} songs.\\n'.format(n_songs=artist.num_songs))\n",
     "\n",
-    "        print('Done.')\n",
+    "        print('Done.\\n')\n",
     "        return artist                    \n",
     "    "
    ]
@@ -418,6 +433,48 @@
    "metadata": {},
    "source": [
     "## Example usage of the song and artist search functions ##"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "G = Genius()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Searching for \"Begin Again\"...\n"
+     ]
+    },
+    {
+     "ename": "UnicodeEncodeError",
+     "evalue": "'ascii' codec can't encode character u'\\u200b' in position 0: ordinal not in range(128)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mUnicodeEncodeError\u001b[0m                        Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-12-4ea6a8ec21f2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msong\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mG\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msearch_song\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Begin Again'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0msong\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-9-d7f71b2342e5>\u001b[0m in \u001b[0;36msearch_song\u001b[0;34m(self, song_title, artist_name)\u001b[0m\n\u001b[1;32m     17\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mi\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_hits\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m             \u001b[0msearch_hit\u001b[0m   \u001b[0;34m=\u001b[0m \u001b[0mjson_search\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'hits'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mi\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'result'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m             \u001b[0mfound_title\u001b[0m  \u001b[0;34m=\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msearch_hit\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'title'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtranslate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' '\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlower\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     20\u001b[0m             \u001b[0mfound_artist\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msearch_hit\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'primary_artist'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'name'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtranslate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' '\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlower\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mUnicodeEncodeError\u001b[0m: 'ascii' codec can't encode character u'\\u200b' in position 0: ordinal not in range(128)"
+     ]
+    }
+   ],
+   "source": [
+    "song = G.search_song('Begin Again')\n",
+    "song\n",
+    "\n"
    ]
   },
   {

--- a/genius/genius.py
+++ b/genius/genius.py
@@ -21,13 +21,13 @@ __description__  = 'A Python wrapper around the Genius.com API'
 #
 #    python genius.py --search_artist Common
 
-
 import re
+from string import punctuation
 import requests
-import json
 from bs4 import BeautifulSoup
 import urllib2
 import socket
+import json
 
 class _GeniusAPI(object):
     # This is a superclass that Genius() inherits from. Not sure if this makes any sense, but it
@@ -98,7 +98,7 @@ class _GeniusAPI(object):
                 print("Timeout raised and caught")
                 continue
             break
-
+                                
         return json.loads(raw)['response']
         
     def _format_api_request(self, term_and_type, page=1):
@@ -143,11 +143,14 @@ class Genius(_GeniusAPI):
         # Loop through search results, stopping as soon as title and artist of result match request
         n_hits = min(10,len(json_search['hits']))
         for i in range(n_hits):
-            search_hit   = json_search['hits'][i]['result']
-            found_title  = str(search_hit['title']).translate(None,' ').lower()
-            found_artist = str(search_hit['primary_artist']['name']).translate(None,' ').lower()
-
-            if found_title == song_title.translate(None,' ').lower() and (found_artist == artist_name.translate(None,' ').lower() or artist_name==''):
+            search_hit   = json_search['hits'][i]['result']                                                            
+            
+            found_title  = str(search_hit['title'].encode('ascii', errors='ignore')).lower().translate(None, punctuation)
+            found_artist = str(search_hit['primary_artist']['name'].encode('ascii', errors='ignore')).lower().translate(None, punctuation)
+                                    
+            # Download song from Genius.com if title and artist match the request
+            if found_title == song_title.lower().translate(None, punctuation) and \
+              (found_artist == artist_name.translate(None, punctuation).lower() or artist_name==''):
                 # Found correct song, accessing API ID
                 json_song = self._make_api_request((search_hit['id'],'song'))
                 
@@ -156,6 +159,7 @@ class Genius(_GeniusAPI):
 
                 # Create the Song object
                 song = Song(json_song, lyrics)
+                                
                 print('Done.\n')        
                 return song
         
@@ -170,9 +174,10 @@ class Genius(_GeniusAPI):
     
         # Perform a Genius API search for the artist                
         json_search = self._make_api_request((artist_name,'search'))                        
-        for hit in json_search['hits']:                                          
-            if str(hit['result']['primary_artist']['name']).lower()==artist_name.lower():                
-                artist_id = str(hit['result']['primary_artist']['id'])                                                                
+        for hit in json_search['hits']:
+            found_artist = hit['result']['primary_artist']
+            if str(found_artist['name'].encode('ascii',errors='ignore')).lower()==artist_name.lower():                
+                artist_id = found_artist['id']
                 break
             else:                                                            
                 artist_id = None                                                                                        
@@ -221,7 +226,7 @@ class Genius(_GeniusAPI):
             print('Found {n_songs} songs.\n'.format(n_songs=artist.num_songs))
 
         print('Done.\n')
-        return artist                    
+        return artist                
     
 
 class Song():    
@@ -239,17 +244,17 @@ class Song():
         try: self._body = json_dict['song']
         except: self._body = json_dict
         self._body['lyrics'] = lyrics
-        self._url      = str(self._body['url'])
-        self._api_path = str(self._body['api_path'])
-        self._id       = str(self._body['id'])  
+        self._url      = self._body['url']
+        self._api_path = self._body['api_path']
+        self._id       = self._body['id']
                                                         
     @property
     def title(self):
-        return str(self._body['title'])
+        return str(self._body['title'].encode('ascii',errors='ignore'))
 
     @property
     def artist(self):
-        return str(self._body['primary_artist']['name'])
+        return str(self._body['primary_artist']['name'].encode('ascii',errors='ignore'))
 
     @property
     def lyrics(self):
@@ -257,24 +262,24 @@ class Song():
         
     @property
     def album(self):
-        try: return str(self._body['album']['name'])
+        try: return self._body['album']['name']
         except: return ''
             
     @property
     def year(self):
-        return str(self._body['release_date'])
+        return self._body['release_date']
     
     @property
     def url(self):
-        return str(self._body['url'])
+        return self._body['url']
     
     @property
     def album_url(self):
-        return str(self._body['album']['url'])
+        return self._body['album']['url']
     
     @property
     def featured_artists(self):
-        return str(self._body['featured_artists'])
+        return self._body['featured_artists']
     
     @property
     def media(self):
@@ -285,14 +290,13 @@ class Song():
     @property
     def writer_artists(self):
         """List of artists credited as writers"""
-        writers = []
-        [writers.append((str(writer['name']),str(writer['id']),str(writer['url'])))\
-                        for writer in self._body['writer_artists']]
+        writers = []                
+        [writers.append((writer['name'], writer['id'], writer['url'])) for writer in self._body['writer_artists']]
         return writers
     
     @property
     def song_art_image_url(self):
-        return str(self._body['song_art_image_url'])
+        return self._body['song_art_image_url']
 
     def __str__(self):
         """Return a string representation of the Song object."""
@@ -323,19 +327,19 @@ class Artist():
     def __init__(self, json_dict):
         """Populate the Artist object with the data from *json_dict*"""
         self._body = json_dict['artist']
-        self._url      = str(self._body['url'])
-        self._api_path = str(self._body['api_path'])
-        self._id       = str(self._body['id']) 
+        self._url      = self._body['url']
+        self._api_path = self._body['api_path']
+        self._id       = self._body['id']
         self._songs = []
         self._num_songs = len(self._songs)
         
     @property
-    def name(self):
-        return str(self._body['name'])
+    def name(self):            
+        return str(self._body['name'].encode('ascii',errors='ignore'))
                     
     @property
     def image_url(self):
-        return str(self._body['image_url'])        
+        return self._body['image_url']
     
     @property
     def songs(self):
@@ -372,9 +376,7 @@ class Artist():
             return '{0}, {1} songs'.format(self.name,self._num_songs)
     
     def __repr__(self):
-        return repr((self.name, '{0} songs'.format(self._num_songs)))  
-
-
+        return repr((self.name, '{0} songs'.format(self._num_songs))) 
 
 
 # --------------------------------------------------------------------
@@ -401,15 +403,6 @@ if __name__ == "__main__":
         print(artist)    
         
     print('\n')
-    
-         
-    
-    
-    
-    
-    
-    
-    
-    
+                 
     
     


### PR DESCRIPTION
This pull request resolves #5 (UnicodeError) and resolves #4 (searching requires exact phrases)

The UnicodeError is addressed by encoding song search results from ```utf-8``` to ```ascii```, ignoring any errors that result. This isn't the best solution, we're potentially losing meaningful characters from artist or song names, but I don't really care about that right now. It's more important to avoid an error when parsing a song name.

The exact phrase issue is addressed by stripping all punctuation from the user's search and the returned results during comparison. This will fix the issue of a search for ```"Hello Goodbye"``` not finding ```"Hello, Goodbye"``` by The Beatles.

Both of these issues could be addressed more thoroughly, but they should do the job for now.